### PR TITLE
 Update to using corrected softdrop mass

### DIFF
--- a/Utils/src/JetProperties.cc
+++ b/Utils/src/JetProperties.cc
@@ -257,7 +257,7 @@ class NamedPtr_softDropMass : public NamedPtr<double> {
 			LorentzVector fatJet;
 			auto const & subjets = Jet.subjets(extraInfo.at(0));
 			for ( auto const & it : subjets ) {
-				fatJet += it->correctedP4(0);
+				fatJet += it->p4();
 			}
 			push_back(fatJet.M());
 		}


### PR DESCRIPTION
Hey Alexx, 

This is the fix for the soft-drop mass switching from using the uncorrected subjets to the corrected subjets. Aside from this nothing is changed on your branch Run2_2017_UpdateDeepDoubleB. 

-Rishi